### PR TITLE
remove carla vst plugins

### DIFF
--- a/studio.kx.carla.json
+++ b/studio.kx.carla.json
@@ -219,6 +219,9 @@
         "install -Dm644 appdata.xml /app/share/appdata/studio.kx.carla.appdata.xml",
         "install -d /app/extensions/Plugins"
       ],
+      "cleanup": [
+        "/lib/vst/carla.vst/"
+      ],
       "sources": [
         {
           "type": "git",


### PR DESCRIPTION
Carla builds itself as vst plugins (Patchbay and Rack) but as far as I can see, there is no use for them in this flatpak. Remember this is only the standalone version of Carla, other hosts can't see the plugins from that flatpak anyway, so only Carla itself could use the Carla VST plugins.
But all the vst plugins provided by Carla are also available as internal and lv2 ones, so I think it is save to remove the vst ones.
Correct me if I'm wrong @falkTX.

Btw. the VST plugins are 29.9 MB in size and waste ~35% of the total flatpak size (85.2 MB).

Also @falkTX would be better to have a build option to not build vst plugins instead of deleting them after they are built. Is there already such an option (planned)?