### PR TITLE
Hopefully fix crashes(?)

### DIFF
--- a/studio.kx.carla.json
+++ b/studio.kx.carla.json
@@ -9,7 +9,7 @@
     "finish-args": [
         "--share=ipc",
         "--socket=wayland",
-        "--socket=fallback-x11",
+        "--socket=x11",
         "--socket=pulseaudio",
         "--device=all",
         "--filesystem=xdg-run/pipewire-0",

--- a/studio.kx.carla.json
+++ b/studio.kx.carla.json
@@ -237,8 +237,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/falkTX/Carla.git",
-                    "tag": "v2.4.1",
-                    "commit": "51028655d09c9a21fc51cadd7bc48210295aa791",
+                    "commit": "afc25ae3137be9cb7addedd16ff45fbe0ab4ea97",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"

--- a/studio.kx.carla.json
+++ b/studio.kx.carla.json
@@ -8,11 +8,12 @@
     "rename-icon": "carla",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
         "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=all",
         "--filesystem=xdg-run/pipewire-0",
+        "--system-talk-name=org.freedesktop.RealtimeKit1",
         "--filesystem=home",
         "--env=TMPDIR=/var/tmp",
         "--env=ALSA_CONFIG_PATH="

--- a/studio.kx.carla.json
+++ b/studio.kx.carla.json
@@ -44,6 +44,26 @@
         }
     },
     "modules": [
+        {
+            "name": "pipewire",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dgstreamer=disabled",
+                "-Dman=disabled",
+                "-Dsystemd=disabled",
+                "-Dudev=disabled",
+                "-Dudevrulesdir=disabled",
+                "-Dsession-managers=['']"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/pipewire/pipewire.git",
+                    "tag": "0.3.48",
+                    "commit": "6c4d3a51583f823b789b0de2df1e36d6c2f8dff8"
+                }
+            ]
+        },
         "shared-modules/linux-audio/fluidsynth2.json",
         {
             "name": "pyqt",

--- a/studio.kx.carla.json
+++ b/studio.kx.carla.json
@@ -8,12 +8,11 @@
     "rename-icon": "carla",
     "finish-args": [
         "--share=ipc",
-        "--socket=wayland",
         "--socket=x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--device=all",
         "--filesystem=xdg-run/pipewire-0",
-        "--system-talk-name=org.freedesktop.RealtimeKit1",
         "--filesystem=home",
         "--env=TMPDIR=/var/tmp",
         "--env=ALSA_CONFIG_PATH="
@@ -59,8 +58,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/pipewire/pipewire.git",
-                    "tag": "0.3.48",
-                    "commit": "6c4d3a51583f823b789b0de2df1e36d6c2f8dff8"
+                    "tag": "0.3.43",
+                    "commit": "07724b7aefa8a23a016727b53f4e426ecd63d248"
                 }
             ]
         },
@@ -113,8 +112,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://files.pythonhosted.org/packages/ab/61/1a1613e3dcca483a7aa9d446cb4614e6425eb853b90db131c305bd9674cb/pyparsing-3.0.6.tar.gz",
-                            "sha256": "d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81",
+                            "url": "https://files.pythonhosted.org/packages/d6/60/9bed18f43275b34198eb9720d4c1238c68b3755620d20df0afd89424d32b/pyparsing-3.0.7.tar.gz",
+                            "sha256": "18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
                             "x-checker-data": {
                                 "type": "pypi",
                                 "name": "pyparsing"
@@ -176,8 +175,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://files.pythonhosted.org/packages/07/4e/0de6d5872145f4cedf187aa8a9069ba91d7e293a82cbbaeabd10c45e9cf0/sip-6.5.0.tar.gz",
-                            "sha256": "a1cf8431a8eb9392b3ff6dc61d832d0447bfdcae5b3e4256a5fa74dbc25b0734",
+                            "url": "https://files.pythonhosted.org/packages/de/c1/9ac5596c10f6ce28abc1849ed1b6299b3953af0b6ff21e227024991a517e/sip-6.5.1.tar.gz",
+                            "sha256": "204f0240db8999a749d638a987b351861843e69239b811ec3d1881412c3706a6",
                             "x-checker-data": {
                                 "type": "pypi",
                                 "name": "sip"
@@ -194,8 +193,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://files.pythonhosted.org/packages/b1/40/dd8f081f04a12912b65417979bf2097def0af0f20c89083ada3670562ac5/PyQt5_sip-12.9.0.tar.gz",
-                            "sha256": "d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32",
+                            "url": "https://files.pythonhosted.org/packages/c0/86/6b60c6a1b1d10524ed50fc4c6a2989492512bd46292a711318a53b243774/PyQt5_sip-12.9.1.tar.gz",
+                            "sha256": "2f24f299b44c511c23796aafbbb581bfdebf78d0905657b7cee2141b4982030e",
                             "x-checker-data": {
                                 "type": "pypi",
                                 "name": "pyqt5-sip"
@@ -244,9 +243,9 @@
                 }
             },
             "post-install": [
+                "sed -i 's/<release /<release date=\"2022-02-19\" /g' ${FLATPAK_DEST}/share/appdata/studio.kx.carla.appdata.xml",
                 "mv ${FLATPAK_DEST}/bin/carla ${FLATPAK_DEST}/bin/carla.bin",
                 "install -Dm755 carla-wrap.sh ${FLATPAK_DEST}/bin/carla",
-                "install -Dm644 appdata.xml /app/share/appdata/${FLATPAK_ID}.appdata.xml",
                 "install -d /app/extensions/Plugins"
             ],
             "cleanup": [
@@ -257,15 +256,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/falkTX/Carla.git",
-                    "commit": "afc25ae3137be9cb7addedd16ff45fbe0ab4ea97",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
-                    }
-                },
-                {
-                    "type": "file",
-                    "path": "appdata.xml"
+                    "commit": "f1d7b590204073c7aaecbbc402f40623021aa420"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
I noticed that Carla as a flatpak is more unstable compared to Carla running native. One way to get it to crash over and over again is when playing something from YouTube in Firefox and trying to route this playback through x42-eq stereo. This always makes Carla as flatpak crash, but not non-flatpak Carla.

This is not ready for merge, just testing / guessing, not sure exactly what the problem could be. Remember from the initial PR, I removed the `"--system-talk-name=org.freedesktop.RealtimeKit1"`, but @hfiguiere said:

> Some app crash if they don't have access to it - speaking from experience here.

So I readded it, hope it helps, will test when I have some time.
If it not works, I'm very open to suggestions :)