### PR TITLE
update release date for v2.5.9

### DIFF
--- a/studio.kx.carla.json
+++ b/studio.kx.carla.json
@@ -87,7 +87,7 @@
                 }
             },
             "post-install": [
-                "sed -i 's/<release /<release date=\"2024-01-18\" /g' ${FLATPAK_DEST}/share/appdata/studio.kx.carla.appdata.xml",
+                "sed -i 's/<release /<release date=\"2024-09-22\" /g' ${FLATPAK_DEST}/share/appdata/studio.kx.carla.appdata.xml",
                 "mv ${FLATPAK_DEST}/bin/carla ${FLATPAK_DEST}/bin/carla.bin",
                 "install -Dm755 carla-wrap.sh ${FLATPAK_DEST}/bin/carla",
                 "install -d /app/extensions/Plugins"


### PR DESCRIPTION
@hfiguiere upstream does not set a release date so we have to manually update it. You forgot it in your PR here: https://github.com/flathub/studio.kx.carla/pull/100